### PR TITLE
Code standards updated to PHP 7.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0]
 
     steps:
     - name: Checkout code
@@ -26,5 +26,5 @@ jobs:
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress --no-interaction --no-suggest
 
-    - name: Run test suite
+    - name: Run php lint
       run: php -l src/Codeception/Module/DataFactory.php

--- a/composer.json
+++ b/composer.json
@@ -1,26 +1,28 @@
 {
-    "name":"codeception/module-datafactory",
-    "description":"DataFactory module for Codeception",
-    "keywords":["codeception"],
-    "homepage":"http://codeception.com/",
-    "type":"library",
-    "license":"MIT",
-    "authors":[
-        {
-            "name":"Michael Bodnarchuk"
-        }
-    ],
-    "minimum-stability": "RC",
-    "require": {
-        "php": ">=5.6.0 <9.0",
-        "codeception/codeception": "^4.0",
-        "league/factory-muffin": "^3.0",
-        "league/factory-muffin-faker": "^2.1"
-    },
-    "autoload":{
-        "classmap": ["src/"]
-    },
-    "config": {
-        "classmap-authoritative": true
-    }
+	"name": "codeception/module-datafactory",
+	"description": "DataFactory module for Codeception",
+	"keywords": [ "codeception" ],
+	"homepage": "https://codeception.com/",
+	"type": "library",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Michael Bodnarchuk"
+		}
+	],
+	"minimum-stability": "RC",
+	"require": {
+		"php": "^7.1 || ^8.0",
+		"codeception/codeception": "^4.0",
+		"league/factory-muffin": "^3.0",
+		"league/factory-muffin-faker": "^2.1"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"config": {
+		"classmap-authoritative": true
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,10 @@ A data factory module for Codeception.
 [![Total Downloads](https://poser.pugx.org/codeception/module-datafactory/downloads)](https://packagist.org/packages/codeception/module-datafactory)
 [![License](https://poser.pugx.org/codeception/module-datafactory/license)](/LICENSE)
 
+## Requirements
+
+* `PHP 7.1` or higher.
+
 ## Installation
 
 ```


### PR DESCRIPTION
- The minimum version of PHP is now 7.1
- Added strict types
- Added return types
- Added typehints
- Removed unnecessary qualifiers