### PR TITLE
Improved support for Codeception 5/PHP 8

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,5 @@
 /tests           export-ignore
 /.gitattributes  export-ignore
 /.gitignore      export-ignore
-/Robofile.php    export-ignore
 /*.md            export-ignore
 /*.yml           export-ignore

--- a/composer.json
+++ b/composer.json
@@ -1,28 +1,31 @@
 {
 	"name": "codeception/module-datafactory",
 	"description": "DataFactory module for Codeception",
-	"keywords": [ "codeception" ],
-	"homepage": "https://codeception.com/",
-	"type": "library",
 	"license": "MIT",
+	"type": "library",
+	"keywords": [
+		"codeception"
+	],
 	"authors": [
 		{
 			"name": "Michael Bodnarchuk"
 		}
 	],
-	"minimum-stability": "dev",
+	"homepage": "https://codeception.com/",
 	"require": {
 		"php": "^8.0",
-		"codeception/codeception": "dev-5.0-interfaces as 5.0.x-dev",
+		"codeception/codeception": "dev-5.0-interfaces as 5.0.0",
 		"league/factory-muffin": "^3.3",
 		"league/factory-muffin-faker": "^2.3"
 	},
+	"minimum-stability": "dev",
 	"autoload": {
 		"classmap": [
 			"src/"
 		]
 	},
 	"config": {
-		"classmap-authoritative": true
+		"classmap-authoritative": true,
+		"sort-packages": true
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
 		"league/factory-muffin": "^3.3",
 		"league/factory-muffin-faker": "^2.3"
 	},
+	"conflict": {
+		"codeception/codeception": "<5.0"
+	},
 	"minimum-stability": "dev",
 	"autoload": {
 		"classmap": [

--- a/src/Codeception/Module/DataFactory.php
+++ b/src/Codeception/Module/DataFactory.php
@@ -179,12 +179,18 @@ EOF;
 
     public ?FactoryMuffin $factoryMuffin = null;
 
-    protected array $config = ['factories' => null, 'customStore' => null];
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $config = [
+        'factories' => null,
+        'customStore' => null,
+    ];
 
     public function _requires(): array
     {
         return [
-            FactoryMuffin::class => '"league/factory-muffin": "^3.0"',
+            FactoryMuffin::class => '"league/factory-muffin": "^3.3"',
         ];
     }
 
@@ -243,7 +249,9 @@ EOF;
 
     public function _depends(): array
     {
-        return [ORM::class => $this->dependencyMessage];
+        return [
+            ORM::class => $this->dependencyMessage,
+        ];
     }
 
     /**


### PR DESCRIPTION
I still need to do the following:

- [x] Consolidate `composer.json` changes with other Codeception modules.
- [x] Convert stray tabs to spaces (or at least consistent with the current codebase).
- [x] Correct commit message to be consistent with repository.

Bonus points (for a separate PR maybe):
- [ ] PHPStan (using config from [`module-doctrine2`](https://github.com/Codeception/module-doctrine2/blob/master/phpstan.neon))