### PR TITLE
Basic PHPStan Configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,3 +28,6 @@ jobs:
 
     - name: Run php lint
       run: php -l src/Codeception/Module/DataFactory.php
+
+    - name: Run source code analysis
+      run: php vendor/bin/phpstan

--- a/codeception.yml
+++ b/codeception.yml
@@ -1,7 +1,0 @@
-paths:
-    tests: tests
-    output: tests/_output
-    data: tests/_data
-    support: tests/_support
-    envs: tests/_envs
-actor_suffix: Tester

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
 		"league/factory-muffin": "^3.3",
 		"league/factory-muffin-faker": "^2.3"
 	},
+	"require-dev": {
+		"phpstan/phpstan": "^1.0"
+	},
 	"conflict": {
 		"codeception/codeception": "<5.0"
 	},

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+  level: 6
+  paths:
+    - src
+  checkMissingIterableValueType: true
+  reportUnmatchedIgnoredErrors: true

--- a/src/Codeception/Module/DataFactory.php
+++ b/src/Codeception/Module/DataFactory.php
@@ -171,9 +171,9 @@ modules:
 EOF;
 
     /**
-     * ORM module on which we we depend on.
+     * ORM module on which we depend on.
      *
-     * @var Module
+     * @var ORM|null
      */
     public ?ORM $ormModule = null;
 
@@ -187,6 +187,9 @@ EOF;
         'customStore' => null,
     ];
 
+    /**
+     * @return array<string, string>
+     */
     public function _requires(): array
     {
         return [
@@ -194,7 +197,10 @@ EOF;
         ];
     }
 
-    public function _beforeSuite($settings = [])
+    /**
+     * @param array<string, mixed> $settings
+     */
+    public function _beforeSuite(array $settings = []): void
     {
         $store = $this->getStore();
         $this->factoryMuffin = new FactoryMuffin($store);
@@ -232,7 +238,7 @@ EOF;
         $this->ormModule = $orm;
     }
 
-    public function _after(TestInterface $test)
+    public function _after(TestInterface $test): void
     {
         $skipCleanup = array_key_exists('cleanup', $this->config) && $this->config['cleanup'] === false;
         $cleanupOrmModuleConfig = $this->ormModule->_getConfig('cleanup');
@@ -247,6 +253,9 @@ EOF;
         $this->factoryMuffin->deleteSaved();
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function _depends(): array
     {
         return [
@@ -257,14 +266,14 @@ EOF;
     /**
      * @throws ModuleException
      */
-    public function onReconfigure($settings = [])
+    public function onReconfigure(): void
     {
         $skipCleanup = array_key_exists('cleanup', $this->config) && $this->config['cleanup'] === false;
         if (!$skipCleanup && !$this->ormModule->_getConfig('cleanup')) {
             $this->factoryMuffin->deleteSaved();
         }
 
-        $this->_beforeSuite($settings);
+        $this->_beforeSuite($this->config);
     }
 
     /**
@@ -277,6 +286,7 @@ EOF;
      * ]);
      * ```
      *
+     * @param array<string, mixed> $fields
      * @throws FactoryMuffinDefinitionAlreadyDefinedException
      */
     public function _define(string $model, array $fields): Definition
@@ -293,6 +303,8 @@ EOF;
      * ```
      *
      * Returns an instance of created user.
+     *
+     * @param array<string, mixed> $extraAttrs
      */
     public function have(string $name, array $extraAttrs = []): object
     {
@@ -310,6 +322,8 @@ EOF;
      * ```
      *
      * Returns an instance of created user without creating a record in database.
+     *
+     * @param array<string, mixed> $extraAttrs
      */
     public function make(string $name, array $extraAttrs = []): object
     {
@@ -324,6 +338,7 @@ EOF;
      * $I->haveMultiple('User', 10, ['is_active' => true]); // create 10 active users
      * ```
      *
+     * @param array<string, mixed> $extraAttrs
      * @return object[]
      */
     public function haveMultiple(string $name, int $times, array $extraAttrs = []): array


### PR DESCRIPTION
Taking the configuration from [`module-doctrine2`](https://github.com/Codeception/module-doctrine2/blob/master/phpstan.neon) and applying it to this codebase has been fairly trivial.

Only current roadblock is the `ORM` interface from the core Codeception codebase is an empty interface and should be an intersection type with the `Codeception\Module` class. Using PHP types/Doctypes we want `(ORM&Module)|null` but this might not be possible? [Curiously a trivial example is valid in the PHPStan playground](https://phpstan.org/r/ba9d3a76-830d-48c1-8615-08b933326e2a) however this may be a config issue on my end. I'll continue to investigate this but if someone else knows what I'm doing wrong/what the issue is then please sing out.