### PR TITLE
Support for Codeception 5.0.0-RC6

### DIFF
--- a/src/Codeception/Module/DataFactory.php
+++ b/src/Codeception/Module/DataFactory.php
@@ -175,10 +175,7 @@ EOF;
 
     public ?FactoryMuffin $factoryMuffin = null;
 
-    /**
-     * @var array
-     */
-    protected $config = ['factories' => null, 'customStore' => null];
+    protected array $config = ['factories' => null, 'customStore' => null];
 
     public function _requires(): array
     {


### PR DESCRIPTION
Fix error: `PHP Fatal error:  Type of Codeception\Module\DataFactory::$config must be array (as in class Codeception\Module)`